### PR TITLE
Add material themed UI with about page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Anobi
+# Anobi Marketing Portal
+
+This repository contains a small Flask web application for marketers. The app
+includes a Materialize styled UI with login and registration, an about page,
+a dashboard showing sample marketing news and posting times and a basic AI chat
+interface implemented with simple rules. User accounts are stored in Firebase
+Firestore so you will need a service account to run the app.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+
+### Firebase setup
+
+Create a Firebase project and download a service account JSON file. Set the
+`FIREBASE_CRED` environment variable to the path of this file before starting
+the server. The app uses Firestore to store user credentials.
+
+The server will start on `http://127.0.0.1:5000/`.
+
+Once running you can visit `/about` to read more about the portal.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,123 @@
+import os
+from flask import Flask, render_template, request, redirect, url_for, session
+import firebase_admin
+from firebase_admin import credentials, firestore
+
+app = Flask(__name__)
+app.secret_key = 'supersecretkey'
+
+# Initialize Firebase using a service account json file specified via the
+# FIREBASE_CRED environment variable.  This allows the app to store and
+# retrieve user credentials in Firestore.
+cred_path = os.environ.get("FIREBASE_CRED", "firebase_service_account.json")
+if os.path.exists(cred_path):
+    cred = credentials.Certificate(cred_path)
+    firebase_admin.initialize_app(cred)
+    DB = firestore.client()
+else:
+    DB = None
+
+
+# Fake news and posting schedule data
+NEWS = [
+    "Social media marketing trends for 2025",
+    "10 tips to boost engagement",
+    "New algorithm changes on major platforms"
+]
+POST_TIMES = [
+    "Best time to post on Twitter: 12pm-3pm",
+    "Best time to post on Instagram: 4pm-6pm"
+]
+
+class SimpleAgent:
+    def respond(self, message: str) -> str:
+        message_lower = message.lower()
+        if 'followers' in message_lower:
+            return "Focus on quality content and consistent posting to grow followers."
+        if 'content' in message_lower:
+            return "Engage with your audience by asking questions and sharing insights."
+        return "That's interesting! Tell me more about your marketing goals."
+
+agent = SimpleAgent()
+
+
+def get_user(username: str):
+    """Fetch a user document from Firestore."""
+    if DB:
+        doc = DB.collection("users").document(username).get()
+        if doc.exists:
+            return doc.to_dict()
+    return None
+
+
+def create_user(username: str, password: str) -> bool:
+    """Create a new user. Returns True on success, False if user exists."""
+    if not DB:
+        return False
+    if get_user(username):
+        return False
+    DB.collection("users").document(username).set({"password": password})
+    return True
+
+@app.route('/')
+def index():
+    if 'username' in session:
+        return redirect(url_for('dashboard'))
+    return render_template('index.html')
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    error = None
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        user = get_user(username)
+        if user and user.get("password") == password:
+            session['username'] = username
+            return redirect(url_for('dashboard'))
+        error = 'Invalid credentials'
+    return render_template('login.html', error=error)
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    """Allow new users to create an account."""
+    message = None
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        if create_user(username, password):
+            session['username'] = username
+            return redirect(url_for('dashboard'))
+        message = 'User already exists'
+    return render_template('register.html', message=message)
+
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect(url_for('login'))
+
+@app.route('/dashboard')
+def dashboard():
+    if 'username' not in session:
+        return redirect(url_for('login'))
+    return render_template('dashboard.html', news=NEWS, times=POST_TIMES)
+
+@app.route('/chat', methods=['GET', 'POST'])
+def chat():
+    if 'username' not in session:
+        return redirect(url_for('login'))
+    response = None
+    if request.method == 'POST':
+        user_msg = request.form.get('message', '')
+        response = agent.respond(user_msg)
+    return render_template('chat.html', response=response)
+
+
+@app.route('/about')
+def about():
+    """Render the about page with information about the portal."""
+    return render_template('about.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.3
+firebase-admin==6.4.0

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block title %}About Us{% endblock %}
+{% block content %}
+  <h4>About Anobi</h4>
+  <p>Anobi is a one-stop solution for marketers. The portal provides marketing news, best posting times and an AI agent to brainstorm content ideas.</p>
+  <p>Join us to stay ahead of trends and engage your audience effectively.</p>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+<head>
+  <title>{% block title %}Anobi{% endblock %}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+</head>
+<body>
+  <nav>
+    <div class="nav-wrapper teal">
+      <a href="{{ url_for('index') }}" class="brand-logo" style="padding-left:10px;">Anobi</a>
+      <ul id="nav-mobile" class="right hide-on-med-and-down">
+        {% if 'username' in session %}
+          <li><a href="{{ url_for('dashboard') }}">Dashboard</a></li>
+          <li><a href="{{ url_for('chat') }}">Chat</a></li>
+          <li><a href="{{ url_for('about') }}">About</a></li>
+          <li><a href="{{ url_for('logout') }}">Logout</a></li>
+        {% else %}
+          <li><a href="{{ url_for('login') }}">Login</a></li>
+          <li><a href="{{ url_for('register') }}">Register</a></li>
+          <li><a href="{{ url_for('about') }}">About</a></li>
+        {% endif %}
+      </ul>
+    </div>
+  </nav>
+  <div class="container" style="margin-top:20px;">
+    {% block content %}{% endblock %}
+  </div>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Chat{% endblock %}
+{% block content %}
+  <h4>AI Agent</h4>
+  <form method="post">
+    <div class="input-field">
+      <textarea id="message" name="message" class="materialize-textarea" placeholder="Ask me about your marketing..."></textarea>
+      <label for="message">Message</label>
+    </div>
+    <button class="btn waves-effect waves-light" type="submit">Send</button>
+  </form>
+  {% if response %}
+    <div class="card-panel teal lighten-4" style="margin-top:20px;">
+      <strong>Agent:</strong> {{ response }}
+    </div>
+  {% endif %}
+{% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+  <h4>Welcome to the Marketing Dashboard</h4>
+  <div class="section">
+    <h5>Latest News</h5>
+    <ul class="collection">
+      {% for item in news %}
+        <li class="collection-item">{{ item }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div class="section">
+    <h5>Best Times to Post</h5>
+    <ul class="collection">
+      {% for time in times %}
+        <li class="collection-item">{{ time }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+  <a class="btn waves-effect waves-light" href="{{ url_for('chat') }}">Chat with AI Agent</a>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}Home{% endblock %}
+{% block content %}
+  <div class="section center-align">
+    <h3>Welcome to Anobi</h3>
+    <p>Your one stop portal for marketing insights and AI-driven content tips.</p>
+    <a class="btn waves-effect waves-light" href="{{ url_for('login') }}">Login</a>
+    <a class="btn waves-effect waves-light teal" href="{{ url_for('register') }}">Register</a>
+  </div>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Login{% endblock %}
+{% block content %}
+  <h4>Login</h4>
+  <form method="post">
+    <div class="input-field">
+      <input id="username" name="username" type="text" required>
+      <label for="username">Username</label>
+    </div>
+    <div class="input-field">
+      <input id="password" name="password" type="password" required>
+      <label for="password">Password</label>
+    </div>
+    {% if error %}
+      <span class="red-text">{{ error }}</span>
+    {% endif %}
+    <button class="btn waves-effect waves-light" type="submit">Login</button>
+    <p>Don't have an account? <a href="{{ url_for('register') }}">Register</a></p>
+  </form>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Register{% endblock %}
+{% block content %}
+  <h4>Create Account</h4>
+  <form method="post">
+    <div class="input-field">
+      <input id="username" name="username" type="text" required>
+      <label for="username">Username</label>
+    </div>
+    <div class="input-field">
+      <input id="password" name="password" type="password" required>
+      <label for="password">Password</label>
+    </div>
+    {% if message %}
+      <span class="red-text">{{ message }}</span>
+    {% endif %}
+    <button class="btn waves-effect waves-light" type="submit">Register</button>
+  </form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- style pages with Materialize CSS via a base template
- create an About page describing the portal
- link navigation for login, dashboard, chat and about
- integrate Firebase with a registration flow
- add a small homepage with login/register links

## Testing
- `pip install -r requirements.txt`
- `python app.py` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_68703fb8244c832282163175a17df820